### PR TITLE
Remove broken link: E-Open House

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -52,7 +52,5 @@ links:
         url: /our-departments-and-cca/cca
   - title: MK@WL
     url: https://sites.google.com/moe.edu.sg/mkwl/
-  - title: E-Open House
-    url: https://sites.google.com/moe.edu.sg/wtpe-openhouse/home
   - title: Useful Links
     collection: useful-links


### PR DESCRIPTION
Remove broken link: E-Open House (https://sites.google.com/moe.edu.sg/wtpe-openhouse/home)